### PR TITLE
Loose the version pin of boto3

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.9.37
+boto3~=1.9.37
 marshmallow==2.19.2
 PyYAML==5.1.0


### PR DESCRIPTION
The actual version is `1.9.164` and growing. Let the version be loose on the patch, being compatible with other packages that also depends on boto.