### PR TITLE
Merge "defaults" into "hosts" config

### DIFF
--- a/aws_gate/config.py
+++ b/aws_gate/config.py
@@ -133,7 +133,7 @@ def _merge_data(src, dst):
 
 def _merge_defaults(config_data):
     for host in config_data.get("hosts", []):
-        for key, value in config_data.get("defaults").items():
+        for key, value in config_data.get("defaults", {}).items():
             if key not in host:
                 host[key] = value
 
@@ -154,7 +154,7 @@ def load_config_from_files(config_files=None):
 
         if not config_data:
             raise EmptyConfigurationError("Empty configuration data")
-    
+
     _merge_defaults(config_data)
     config = GateConfigSchema().load(config_data)
     return config

--- a/aws_gate/config.py
+++ b/aws_gate/config.py
@@ -131,6 +131,13 @@ def _merge_data(src, dst):
     return dst
 
 
+def _merge_defaults(config_data):
+    for host in config_data.get("hosts", []):
+        for key, value in config_data.get("defaults").items():
+            if key not in host:
+                host[key] = value
+
+
 def load_config_from_files(config_files=None):
     if config_files is None:
         config_files = _locate_config_files()
@@ -147,6 +154,7 @@ def load_config_from_files(config_files=None):
 
         if not config_data:
             raise EmptyConfigurationError("Empty configuration data")
-
+    
+    _merge_defaults(config_data)
     config = GateConfigSchema().load(config_data)
     return config


### PR DESCRIPTION
The change allows to use the configs under the "defaults" section when missing from the "hosts" ones. 

In this way the config file can be more lean, especially when **region** and **profile** are common across a lot of hosts.