### PR TITLE
Add ability to run interactive commands via SSM

### DIFF
--- a/aws_gate/cli.py
+++ b/aws_gate/cli.py
@@ -22,6 +22,7 @@ from aws_gate.constants import (
     DEFAULT_LIST_OUTPUT_FORMATS,
     DEFAULT_LIST_OUTPUT,
 )
+from aws_gate.exec import exec
 from aws_gate.list import list_instances
 from aws_gate.session import session
 from aws_gate.ssh import ssh
@@ -64,6 +65,19 @@ def parse_arguments():
     )
     bootstrap_parser.add_argument(
         "-f", "--force", action="store_true", help="Forces bootstrap operation"
+    )
+
+    # 'exec' subcommand
+    exec_parser = subparsers.add_parser(
+        "exec", help="Execute interactive command on instance"
+    )
+    exec_parser.add_argument("-p", "--profile", help="AWS profile to use")
+    exec_parser.add_argument("-r", "--region", help="AWS region to use")
+    exec_parser.add_argument(
+        "instance_name", help="Instance we wish to execute command on"
+    )
+    exec_parser.add_argument(
+        "command", help="command to execute on the instance", nargs=argparse.REMAINDER
     )
 
     # 'session' subcommand
@@ -227,6 +241,14 @@ def main():
 
     if args.subcommand == "bootstrap":
         bootstrap(force=args.force)
+    if args.subcommand == "exec":
+        exec(
+            config=config,
+            instance_name=args.instance_name,
+            command=args.command,
+            region_name=region,
+            profile_name=profile,
+        )
     if args.subcommand == "session":
         session(
             config=config,

--- a/aws_gate/exec.py
+++ b/aws_gate/exec.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from aws_gate.constants import AWS_DEFAULT_PROFILE, AWS_DEFAULT_REGION
 from aws_gate.decorators import (

--- a/aws_gate/exec.py
+++ b/aws_gate/exec.py
@@ -1,0 +1,76 @@
+import logging
+import os
+
+from aws_gate.constants import AWS_DEFAULT_PROFILE, AWS_DEFAULT_REGION
+from aws_gate.decorators import (
+    plugin_required,
+    plugin_version,
+    valid_aws_profile,
+    valid_aws_region,
+)
+from aws_gate.query import query_instance
+from aws_gate.session_common import BaseSession
+from aws_gate.utils import (
+    get_aws_client,
+    fetch_instance_details_from_config,
+    get_aws_resource,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExecSession(BaseSession):
+    def __init__(
+        self,
+        instance_id,
+        command,
+        region_name=AWS_DEFAULT_REGION,
+        profile_name=AWS_DEFAULT_PROFILE,
+        ssm=None,
+    ):
+        self._instance_id = instance_id
+        self._region_name = region_name
+        self._command = " ".join(command)
+        self._profile_name = profile_name if profile_name is not None else ""
+        self._ssm = ssm
+
+        self._session_parameters = {"Target": self._instance_id}
+
+        self._session_parameters = {
+            "Target": self._instance_id,
+            "DocumentName": "AWS-StartInteractiveCommand",
+            "Parameters": {"command": [self._command]},
+        }
+
+
+@plugin_required
+@plugin_version("1.1.23.0")
+@valid_aws_profile
+@valid_aws_region
+def exec(
+    config,
+    instance_name,
+    command,
+    profile_name=AWS_DEFAULT_PROFILE,
+    region_name=AWS_DEFAULT_REGION,
+):
+    instance, profile, region = fetch_instance_details_from_config(
+        config, instance_name, profile_name, region_name
+    )
+
+    ssm = get_aws_client("ssm", region_name=region, profile_name=profile)
+    ec2 = get_aws_resource("ec2", region_name=region, profile_name=profile)
+
+    instance_id = query_instance(name=instance, ec2=ec2)
+    if instance_id is None:
+        raise ValueError("No instance could be found for name: {}".format(instance))
+
+    logger.info(
+        'Executing command "%s"  on instance %s (%s) via profile %s',
+        " ".join(command),
+        instance_id,
+        region,
+        profile,
+    )
+    with ExecSession(instance_id, command, region_name=region, ssm=ssm) as sess:
+        sess.open()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -128,6 +128,7 @@ def test_cli_get_region(args, config, default, expected):
         ("ssh", "ssh"),
         ("ssh-config", "ssh_config"),
         ("ssh-proxy", "ssh_proxy"),
+        ("exec", "exec"),
     ],
     ids=lambda x: x[0],
 )

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1,0 +1,125 @@
+# pylint: disable=wrong-import-position
+import pytest
+
+from aws_gate.exec import ExecSession, exec  # noqa
+
+
+def test_create_exec_session(ssm_mock, instance_id):
+    sess = ExecSession(instance_id=instance_id, ssm=ssm_mock, command=["ls", "-l"])
+    sess.create()
+
+    assert ssm_mock.start_session.called
+
+
+def test_terminate_exec_session(ssm_mock, instance_id):
+    sess = ExecSession(instance_id=instance_id, command=["ls", "-l"], ssm=ssm_mock)
+
+    sess.create()
+    sess.terminate()
+
+    assert ssm_mock.terminate_session.called
+
+
+def test_open_exec_session(mocker, ssm_mock, instance_id):
+    m = mocker.patch("aws_gate.session_common.execute_plugin", return_value="output")
+    sess = ExecSession(instance_id=instance_id, command=["ls", "-l"], ssm=ssm_mock)
+    sess.open()
+
+    assert m.called
+
+
+def test_exec_session_context_manager(ssm_mock, instance_id):
+    with ExecSession(instance_id=instance_id, command=["ls", "-l"], ssm=ssm_mock):
+        pass
+
+    assert ssm_mock.start_session.called
+    assert ssm_mock.terminate_session.called
+
+
+def test_exec_session(mocker, instance_id, config):
+    mocker.patch("aws_gate.exec.get_aws_client")
+    mocker.patch("aws_gate.exec.get_aws_resource")
+    mocker.patch("aws_gate.exec.query_instance", return_value=instance_id)
+    session_mock = mocker.patch(
+        "aws_gate.exec.ExecSession", return_value=mocker.MagicMock()
+    )
+    mocker.patch("aws_gate.decorators._plugin_exists", return_value=True)
+    mocker.patch("aws_gate.decorators.execute_plugin", return_value="1.1.23.0")
+    mocker.patch("aws_gate.decorators.is_existing_profile", return_value=True)
+
+    exec(
+        config=config,
+        instance_name=instance_id,
+        command={"ls", "-l"},
+        profile_name="profile",
+        region_name="eu-west-1",
+    )
+    assert session_mock.called
+
+
+def test_exec_session_exception_invalid_profile(mocker, instance_id, config):
+    mocker.patch("aws_gate.exec.get_aws_client")
+    mocker.patch("aws_gate.exec.get_aws_resource")
+    mocker.patch("aws_gate.exec.query_instance", return_value=None)
+    mocker.patch("aws_gate.decorators._plugin_exists", return_value=True)
+    mocker.patch("aws_gate.decorators.execute_plugin", return_value="1.1.23.0")
+
+    with pytest.raises(ValueError):
+        exec(
+            config=config,
+            profile_name="invalid-profile",
+            instance_name=instance_id,
+            command=["ls", "-l"],
+        )
+
+
+def test_exec_session_exception_invalid_region(mocker, instance_id, config):
+    mocker.patch("aws_gate.exec.get_aws_client")
+    mocker.patch("aws_gate.exec.get_aws_resource")
+    mocker.patch("aws_gate.exec.query_instance", return_value=None)
+    mocker.patch("aws_gate.decorators._plugin_exists", return_value=True)
+    mocker.patch("aws_gate.decorators.execute_plugin", return_value="1.1.23.0")
+
+    with pytest.raises(ValueError):
+        exec(
+            config=config,
+            region_name="invalid-region",
+            instance_name=instance_id,
+            profile_name="default",
+            command=["ls", "-l"],
+        )
+
+
+def test_exec_session_exception_unknown_instance_id(mocker, instance_id, config):
+    mocker.patch("aws_gate.exec.get_aws_client")
+    mocker.patch("aws_gate.exec.get_aws_resource")
+    mocker.patch("aws_gate.exec.query_instance", return_value=None)
+    mocker.patch("aws_gate.decorators._plugin_exists", return_value=True)
+    mocker.patch("aws_gate.decorators.execute_plugin", return_value="1.1.23.0")
+    mocker.patch("aws_gate.decorators.is_existing_profile", return_value=True)
+
+    with pytest.raises(ValueError):
+        exec(
+            config=config,
+            instance_name=instance_id,
+            command=["ls", "-l"],
+            profile_name="profile",
+            region_name="eu-west-1",
+        )
+
+
+def test_exec_session_without_config(mocker, instance_id, empty_config):
+    mocker.patch("aws_gate.exec.get_aws_client")
+    mocker.patch("aws_gate.exec.get_aws_resource")
+    mocker.patch("aws_gate.exec.query_instance", return_value=None)
+    mocker.patch("aws_gate.decorators._plugin_exists", return_value=True)
+    mocker.patch("aws_gate.decorators.execute_plugin", return_value="1.1.23.0")
+
+    with pytest.raises(ValueError):
+        exec(
+            config=empty_config,
+            instance_name=instance_id,
+            command=["ls", "-l"],
+            profile_name="profile",
+            region_name="eu-west-1",
+        )


### PR DESCRIPTION
Adds `exec` functionality from #356. Suitable for testing. Tests will be added in this PR as well.