### PR TITLE
Concurrent sessions

### DIFF
--- a/aws_gate/cli.py
+++ b/aws_gate/cli.py
@@ -112,11 +112,6 @@ def parse_arguments():
     ssh_parser.add_argument(
         "--key-size", type=int, default=DEFAULT_KEY_SIZE, help=argparse.SUPPRESS
     )
-
-    ssh_parser.add_argument(
-        "-a", "--agent-mode", help="Add private key to ssh agent instead of writing to file", action="store_true"
-    )
-
     ssh_parser.add_argument("instance_name", help="Instance we wish to open session to")
     ssh_parser.add_argument(
         "command", help="command to execute on the instance", nargs=argparse.REMAINDER
@@ -134,9 +129,6 @@ def parse_arguments():
     ssh_config_parser.add_argument(
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
     )
-    ssh_config_parser.add_argument(
-        "-a", "--agent-mode", help="Expect private key in ssh agent", action="store_true"
-    )
 
     # 'ssh-proxy' subcommand
     ssh_proxy_parser = subparsers.add_parser(
@@ -150,10 +142,6 @@ def parse_arguments():
     ssh_proxy_parser.add_argument(
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
     )
-    ssh_proxy_parser.add_argument(
-        "-a", "--agent-mode", help="Add private key to ssh agent instead of writing to file", action="store_true"
-    )
-
     ssh_proxy_parser.add_argument(
         "--key-type",
         type=str,
@@ -279,16 +267,9 @@ def main():
             key_type=args.key_type,
             key_size=args.key_size,
             command=args.command,
-            agent_mode=args.agent_mode
         )
     if args.subcommand == "ssh-config":
-        ssh_config(
-            region_name=region,
-            profile_name=profile,
-            user=args.os_user,
-            port=args.port,
-            agent_mode=args.agent_mode
-        )
+        ssh_config(region_name=region, profile_name=profile, user=args.os_user, port=args.port)
     if args.subcommand == "ssh-proxy":
         ssh_proxy(
             config=config,
@@ -299,7 +280,6 @@ def main():
             port=args.port,
             key_type=args.key_type,
             key_size=args.key_size,
-            agent_mode=args.agent_mode
         )
     if args.subcommand in ["ls", "list"]:
         fields = args.output.split(",")

--- a/aws_gate/cli.py
+++ b/aws_gate/cli.py
@@ -21,6 +21,7 @@ from aws_gate.constants import (
     DEFAULT_LIST_HUMAN_FIELDS,
     DEFAULT_LIST_OUTPUT_FORMATS,
     DEFAULT_LIST_OUTPUT,
+    DEFAULT_KEY_NAME,
 )
 from aws_gate.exec import exec
 from aws_gate.list import list_instances
@@ -129,6 +130,9 @@ def parse_arguments():
     ssh_config_parser.add_argument(
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
     )
+    ssh_config_parser.add_argument(
+        "-f", "--filename", help="Filename for the generated private key", type=str, default=DEFAULT_KEY_NAME
+    )
 
     # 'ssh-proxy' subcommand
     ssh_proxy_parser = subparsers.add_parser(
@@ -141,6 +145,9 @@ def parse_arguments():
     )
     ssh_proxy_parser.add_argument(
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
+    )
+    ssh_proxy_parser.add_argument(
+        "-f", "--filename", help="Filename for the generated private key", type=str, default=DEFAULT_KEY_NAME
     )
     ssh_proxy_parser.add_argument(
         "--key-type",
@@ -269,7 +276,13 @@ def main():
             command=args.command,
         )
     if args.subcommand == "ssh-config":
-        ssh_config(region_name=region, profile_name=profile, user=args.os_user, port=args.port)
+        ssh_config(
+            region_name=region,
+            profile_name=profile,
+            user=args.os_user,
+            port=args.port,
+            key_name=args.filename,
+        )
     if args.subcommand == "ssh-proxy":
         ssh_proxy(
             config=config,
@@ -280,6 +293,7 @@ def main():
             port=args.port,
             key_type=args.key_type,
             key_size=args.key_size,
+            key_name=args.filename,
         )
     if args.subcommand in ["ls", "list"]:
         fields = args.output.split(",")

--- a/aws_gate/cli.py
+++ b/aws_gate/cli.py
@@ -112,6 +112,11 @@ def parse_arguments():
     ssh_parser.add_argument(
         "--key-size", type=int, default=DEFAULT_KEY_SIZE, help=argparse.SUPPRESS
     )
+
+    ssh_parser.add_argument(
+        "-a", "--agent-mode", help="Add private key to ssh agent instead of writing to file", action="store_true"
+    )
+
     ssh_parser.add_argument("instance_name", help="Instance we wish to open session to")
     ssh_parser.add_argument(
         "command", help="command to execute on the instance", nargs=argparse.REMAINDER
@@ -129,6 +134,9 @@ def parse_arguments():
     ssh_config_parser.add_argument(
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
     )
+    ssh_config_parser.add_argument(
+        "-a", "--agent-mode", help="Expect private key in ssh agent", action="store_true"
+    )
 
     # 'ssh-proxy' subcommand
     ssh_proxy_parser = subparsers.add_parser(
@@ -142,6 +150,10 @@ def parse_arguments():
     ssh_proxy_parser.add_argument(
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
     )
+    ssh_proxy_parser.add_argument(
+        "-a", "--agent-mode", help="Add private key to ssh agent instead of writing to file", action="store_true"
+    )
+
     ssh_proxy_parser.add_argument(
         "--key-type",
         type=str,
@@ -267,10 +279,15 @@ def main():
             key_type=args.key_type,
             key_size=args.key_size,
             command=args.command,
+            agent_mode=args.agent_mode
         )
     if args.subcommand == "ssh-config":
         ssh_config(
-            region_name=region, profile_name=profile, user=args.os_user, port=args.port
+            region_name=region,
+            profile_name=profile,
+            user=args.os_user,
+            port=args.port,
+            agent_mode=args.agent_mode
         )
     if args.subcommand == "ssh-proxy":
         ssh_proxy(
@@ -282,6 +299,7 @@ def main():
             port=args.port,
             key_type=args.key_type,
             key_size=args.key_size,
+            agent_mode=args.agent_mode
         )
     if args.subcommand in ["ls", "list"]:
         fields = args.output.split(",")

--- a/aws_gate/constants.py
+++ b/aws_gate/constants.py
@@ -1,6 +1,7 @@
 import os
 
 DEBUG = "GATE_DEBUG" in os.environ
+AGENT_KEY_LIFETIME = os.environ.get('GATE_KEY_LIFETIME') if os.environ.get('GATE_KEY_LIFETIME') is not None else '15'
 
 AWS_DEFAULT_REGION = "eu-west-1"
 AWS_DEFAULT_PROFILE = "default"
@@ -39,8 +40,6 @@ DEFAULT_GATE_CONFIGD_PATH = os.path.join(DEFAULT_GATE_DIR, "config.d")
 PLUGIN_NAME = "session-manager-plugin"
 DEFAULT_GATE_BIN_PATH = os.path.join(DEFAULT_GATE_DIR, "bin")
 PLUGIN_INSTALL_PATH = os.path.join(DEFAULT_GATE_BIN_PATH, PLUGIN_NAME)
-
-DEFAULT_GATE_KEY_PATH = os.path.join(DEFAULT_GATE_DIR, "key")
 
 SSM_PLUGIN_BASE_URL = "https://s3.amazonaws.com/session-manager-downloads/plugin/latest"
 SSM_PLUGIN_PATH = {

--- a/aws_gate/constants.py
+++ b/aws_gate/constants.py
@@ -9,6 +9,7 @@ DEFAULT_OS_USER = "ec2-user"
 DEFAULT_SSH_PORT = 22
 DEFAULT_KEY_ALGORITHM = "rsa"
 DEFAULT_KEY_SIZE = 2048
+DEFAULT_KEY_NAME = "default"
 SUPPORTED_KEY_TYPES = ["rsa", "ed25519"]
 KEY_MIN_SIZE = DEFAULT_KEY_SIZE
 
@@ -33,8 +34,10 @@ DEFAULT_LIST_HUMAN_FIELDS = (
 )
 
 DEFAULT_GATE_DIR = os.path.expanduser("~/.aws-gate")
+DEFAULT_GATE_KEY_DIR = os.path.join(DEFAULT_GATE_DIR, "keys")
 DEFAULT_GATE_CONFIG_PATH = os.path.join(DEFAULT_GATE_DIR, "config")
 DEFAULT_GATE_CONFIGD_PATH = os.path.join(DEFAULT_GATE_DIR, "config.d")
+
 
 PLUGIN_NAME = "session-manager-plugin"
 DEFAULT_GATE_BIN_PATH = os.path.join(DEFAULT_GATE_DIR, "bin")

--- a/aws_gate/constants.py
+++ b/aws_gate/constants.py
@@ -1,7 +1,6 @@
 import os
 
 DEBUG = "GATE_DEBUG" in os.environ
-AGENT_KEY_LIFETIME = os.environ.get('GATE_KEY_LIFETIME') if os.environ.get('GATE_KEY_LIFETIME') is not None else '15'
 
 AWS_DEFAULT_REGION = "eu-west-1"
 AWS_DEFAULT_PROFILE = "default"

--- a/aws_gate/ssh.py
+++ b/aws_gate/ssh.py
@@ -12,6 +12,8 @@ from aws_gate.constants import (
     PLUGIN_INSTALL_PATH,
     DEBUG,
     DEFAULT_GATE_DIR,
+    DEFAULT_GATE_KEY_DIR,
+    DEFAULT_KEY_NAME,
 )
 from aws_gate.decorators import (
     plugin_version,
@@ -152,11 +154,9 @@ def ssh(
         region,
         profile,
     )
-    key_path = "{}/{}.{}.{}".format(
-        DEFAULT_GATE_DIR,
-        instance_id,
-        region_name,
-        profile_name
+    key_path = "{}/{}".format(
+        DEFAULT_GATE_KEY_DIR,
+        DEFAULT_KEY_NAME,
     )
     with SshKey(key_type=key_type, key_size=key_size, key_path=key_path) as ssh_key:
         with SshKeyUploader(

--- a/aws_gate/ssh.py
+++ b/aws_gate/ssh.py
@@ -44,7 +44,6 @@ class SshSession(BaseSession):
         port=DEFAULT_SSH_PORT,
         user=DEFAULT_OS_USER,
         command=None,
-        agent_mode=False
     ):
         self._instance_id = instance_id
         self._region_name = region_name
@@ -54,7 +53,6 @@ class SshSession(BaseSession):
         self._user = user
         self._command = command
         self._key_path = key_path
-        self._agent_mode = agent_mode
 
         self._ssh_cmd = None
 
@@ -92,7 +90,7 @@ class SshSession(BaseSession):
         proxy_command = " ".join(shlex.quote(i) for i in proxy_command_args)
 
         ssh_options = [
-            "IdentitiesOnly={}".format("no" if self._agent_mode else "yes"),
+            "IdentitiesOnly=yes",
             "IdentityFile={}".format(self._key_path),
             "UserKnownHostsFile=/dev/null",
             "StrictHostKeyChecking=no",
@@ -131,7 +129,6 @@ def ssh(
     profile_name=AWS_DEFAULT_PROFILE,
     region_name=AWS_DEFAULT_REGION,
     command=None,
-    agent_mode=False
 ):
     instance, profile, region = fetch_instance_details_from_config(
         config, instance_name, profile_name, region_name
@@ -161,7 +158,7 @@ def ssh(
         region_name,
         profile_name
     )
-    with SshKey(key_type=key_type, key_size=key_size, key_path=key_path, agent_mode=agent_mode) as ssh_key:
+    with SshKey(key_type=key_type, key_size=key_size, key_path=key_path) as ssh_key:
         with SshKeyUploader(
             instance_id=instance_id, az=az, user=user, ssh_key=ssh_key, ec2_ic=ec2_ic
         ):
@@ -173,7 +170,6 @@ def ssh(
                 port=port,
                 user=user,
                 command=command,
-                key_path=key_path,
-                agent_mode=agent_mode
+                key_path=key_path
             ) as ssh_session:
                 ssh_session.open()

--- a/aws_gate/ssh_common.py
+++ b/aws_gate/ssh_common.py
@@ -56,6 +56,10 @@ class SshKey:
         self._generate_key()
 
     def write_to_file(self):
+        key_path = os.path.dirname(self._key_path)
+        if not os.path.isdir(key_path):
+            os.mkdir(key_path)
+
         with open(self._key_path, "wb") as f:
             f.write(self.private_key)
         # 'ssh' refuses to use the key with broad access permissions

--- a/aws_gate/ssh_common.py
+++ b/aws_gate/ssh_common.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -10,12 +9,6 @@ from aws_gate.constants import (
     DEFAULT_KEY_SIZE,
     SUPPORTED_KEY_TYPES,
     DEFAULT_OS_USER,
-    DEBUG,
-    AGENT_KEY_LIFETIME,
-)
-
-from aws_gate.utils import (
-    execute,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,19 +18,17 @@ KEY_MIN_SIZE = DEFAULT_KEY_SIZE
 
 class SshKey:
     def __init__(
-        self, key_path, key_type="rsa", key_size=KEY_MIN_SIZE, agent_mode=False
+        self, key_path, key_type="rsa", key_size=KEY_MIN_SIZE
     ):
         self._key_path = None
         self._key_type = None
         self._key_size = None
         self._private_key = None
         self._public_key = None
-        self._add_to_agent = None
 
         self.key_path = key_path
         self.key_type = key_type
         self.key_size = key_size
-        self.agent_mode = agent_mode
 
     def __enter__(self):
         self.generate()
@@ -65,24 +56,10 @@ class SshKey:
         self._generate_key()
 
     def write_to_file(self):
-        if (self.agent_mode):
-            # When using a public key as IdentityFile ssh will (apparently) load the
-            # corresponding private key file from the ssh agent. This reduces the
-            # number of authentication attempts in case of concurrent use of the proxy.
-            data = self.public_key
-        else:
-            data = self.private_key
-
         with open(self._key_path, "wb") as f:
-            f.write(data)
+            f.write(self.private_key)
         # 'ssh' refuses to use the key with broad access permissions
         os.chmod(self._key_path, 0o600)
-
-        if (self.agent_mode):
-            output = subprocess.DEVNULL
-            if DEBUG:
-                output = None
-            execute('ssh-add', ['-t', AGENT_KEY_LIFETIME, '-'], input=self.private_key, stdout=output, stderr=subprocess.STDOUT)
 
     def delete(self):
         os.remove(self._key_path)

--- a/aws_gate/ssh_config.py
+++ b/aws_gate/ssh_config.py
@@ -6,7 +6,8 @@ from aws_gate.constants import (
     AWS_DEFAULT_REGION,
     DEFAULT_SSH_PORT,
     DEFAULT_OS_USER,
-    DEFAULT_GATE_DIR,
+    DEFAULT_GATE_KEY_DIR,
+    DEFAULT_KEY_NAME,
 )
 from aws_gate.decorators import valid_aws_region, valid_aws_profile
 
@@ -19,16 +20,17 @@ def ssh_config(
     region_name=AWS_DEFAULT_REGION,
     user=DEFAULT_OS_USER,
     port=DEFAULT_SSH_PORT,
+    key_name=DEFAULT_KEY_NAME,
 ):
     PROXY_COMMAND = [
-        r"""sh -c "aws-gate ssh-proxy -l {} -p `echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\3/g'`""".format(user),
+        r"""sh -c "aws-gate ssh-proxy -l {} -f {} -p `echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\3/g'`""".format(user, key_name),
         r"""-r `echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\2/g'`""",
         r'''`echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\1/g'`"''',
     ]
     config = OrderedDict(
         {
             "Host": "*.{}.{}".format(region_name, profile_name),
-            "IdentityFile": "{}/%h".format(DEFAULT_GATE_DIR),
+            "IdentityFile": "{}/{}".format(DEFAULT_GATE_KEY_DIR, key_name),
             "IdentitiesOnly": "yes",
             "User": user,
             "Port": port,

--- a/aws_gate/ssh_config.py
+++ b/aws_gate/ssh_config.py
@@ -19,10 +19,9 @@ def ssh_config(
     region_name=AWS_DEFAULT_REGION,
     user=DEFAULT_OS_USER,
     port=DEFAULT_SSH_PORT,
-    agent_mode=False
 ):
     PROXY_COMMAND = [
-        r"""sh -c "aws-gate ssh-proxy {}-l {} -p `echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\3/g'`""".format("-a " if agent_mode else "", user),
+        r"""sh -c "aws-gate ssh-proxy -l {} -p `echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\3/g'`""".format(user),
         r"""-r `echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\2/g'`""",
         r'''`echo %h | sed -Ee 's/^(.*)\.(.*)\.(.*)$/\\1/g'`"''',
     ]
@@ -30,7 +29,7 @@ def ssh_config(
         {
             "Host": "*.{}.{}".format(region_name, profile_name),
             "IdentityFile": "{}/%h".format(DEFAULT_GATE_DIR),
-            "IdentitiesOnly": "no" if agent_mode else "yes",
+            "IdentitiesOnly": "yes",
             "User": user,
             "Port": port,
             "ProxyCommand": " ".join(PROXY_COMMAND),

--- a/aws_gate/ssh_proxy.py
+++ b/aws_gate/ssh_proxy.py
@@ -3,6 +3,7 @@ import logging
 from aws_gate.constants import (
     AWS_DEFAULT_PROFILE,
     AWS_DEFAULT_REGION,
+    DEFAULT_GATE_DIR,
     DEFAULT_OS_USER,
     DEFAULT_SSH_PORT,
     DEFAULT_KEY_ALGORITHM,
@@ -64,6 +65,7 @@ def ssh_proxy(
     key_size=DEFAULT_KEY_SIZE,
     profile_name=AWS_DEFAULT_PROFILE,
     region_name=AWS_DEFAULT_REGION,
+    agent_mode=False
 ):
     instance, profile, region = fetch_instance_details_from_config(
         config, instance_name, profile_name, region_name
@@ -87,7 +89,14 @@ def ssh_proxy(
         region,
         profile,
     )
-    with SshKey(key_type=key_type, key_size=key_size) as ssh_key:
+
+    key_path = "{}/{}.{}.{}".format(
+        DEFAULT_GATE_DIR,
+        instance_id,
+        region_name,
+        profile_name
+    )
+    with SshKey(key_type=key_type, key_size=key_size, key_path=key_path, agent_mode=agent_mode) as ssh_key:
         with SshKeyUploader(
             instance_id=instance_id, az=az, user=user, ssh_key=ssh_key, ec2_ic=ec2_ic
         ):

--- a/aws_gate/ssh_proxy.py
+++ b/aws_gate/ssh_proxy.py
@@ -8,6 +8,7 @@ from aws_gate.constants import (
     DEFAULT_SSH_PORT,
     DEFAULT_KEY_ALGORITHM,
     DEFAULT_KEY_SIZE,
+    DEFAULT_GATE_KEY_DIR,
 )
 from aws_gate.decorators import (
     plugin_version,
@@ -59,6 +60,7 @@ class SshProxySession(BaseSession):
 def ssh_proxy(
     config,
     instance_name,
+    key_name,
     user=DEFAULT_OS_USER,
     port=DEFAULT_SSH_PORT,
     key_type=DEFAULT_KEY_ALGORITHM,
@@ -89,11 +91,9 @@ def ssh_proxy(
         profile,
     )
 
-    key_path = "{}/{}.{}.{}".format(
-        DEFAULT_GATE_DIR,
-        instance_id,
-        region_name,
-        profile_name
+    key_path = "{}/{}".format(
+        DEFAULT_GATE_KEY_DIR,
+        key_name
     )
     with SshKey(key_type=key_type, key_size=key_size, key_path=key_path) as ssh_key:
         with SshKeyUploader(

--- a/aws_gate/ssh_proxy.py
+++ b/aws_gate/ssh_proxy.py
@@ -65,7 +65,6 @@ def ssh_proxy(
     key_size=DEFAULT_KEY_SIZE,
     profile_name=AWS_DEFAULT_PROFILE,
     region_name=AWS_DEFAULT_REGION,
-    agent_mode=False
 ):
     instance, profile, region = fetch_instance_details_from_config(
         config, instance_name, profile_name, region_name
@@ -96,7 +95,7 @@ def ssh_proxy(
         region_name,
         profile_name
     )
-    with SshKey(key_type=key_type, key_size=key_size, key_path=key_path, agent_mode=agent_mode) as ssh_key:
+    with SshKey(key_type=key_type, key_size=key_size, key_path=key_path) as ssh_key:
         with SshKeyUploader(
             instance_id=instance_id, az=az, user=user, ssh_key=ssh_key, ec2_ic=ec2_ic
         ):

--- a/aws_gate/utils.py
+++ b/aws_gate/utils.py
@@ -125,11 +125,11 @@ def deferred_signals(signal_list=None):
 def execute(cmd, args, **kwargs):
     ret, result = None, None
 
-    env = DEFAULT_GATE_BIN_PATH + os.pathsep + os.environ["PATH"]
-
+    env_path = DEFAULT_GATE_BIN_PATH + os.pathsep + os.environ["PATH"]
+    env = os.environ.copy().update({"PATH": env_path})
     try:
         logger.debug('Executing "%s"', " ".join([cmd] + args))
-        result = subprocess.run([cmd] + args, env={"PATH": env}, check=True, **kwargs)
+        result = subprocess.run([cmd] + args, env=env, check=True, **kwargs)
     except subprocess.CalledProcessError as e:
         logger.error(
             'Command "%s" exited with %s', " ".join([cmd] + args), e.returncode


### PR DESCRIPTION
Hi!

Just checking if you would be willing to accept a hack like this (totally understand if you don't :). It's work in progress at the moment, I got as far as making it work. I've got some time to fix the tests and perhaps refine it a bit if you want.

So my use case is that I occasionally need to run puppet bolt towards a bunch of nodes. In order to run tunnelled sessions concurrently I needed to tweak the application a bit to avoid race conditions with the static private key file. So I changed from writing the private key to a static path to writing the key per instance id.

Unfortunately it seemed that bolt wasn't able to authenticate with the private key on disk, I don't really know why and didn't investigate further. So I added the option to run ssh and ssh-proxy in "agent" mode which basically just adds the key to the ssh agent (with a short lifetime) and writes the public key to disk instead. Apparently if ssh finds a public key in the IdentityFile it will try to load the corresponding private key from the agent. Seems to work fine.
