### PR TITLE
Fix ls to show instances without Name tag

### DIFF
--- a/aws_gate/utils.py
+++ b/aws_gate/utils.py
@@ -193,24 +193,25 @@ def get_multiple_instance_details(instance_ids, ec2=None):
     except botocore.exceptions.ClientError:
         raise AWSConnectionError
 
-    instance_name = None
     instance_details = []
     for ec2_instance in ec2_instances:
+        instance_name = None
         for tag in ec2_instance.tags:
             if tag["Key"] == "Name":
                 instance_name = tag["Value"]
+                break
 
-                instance_details.append(
-                    {
-                        "instance_id": ec2_instance.id,
-                        "instance_name": instance_name,
-                        "availability_zone": ec2_instance.placement["AvailabilityZone"],
-                        "vpc_id": ec2_instance.vpc_id,
-                        "private_ip_address": ec2_instance.private_ip_address or None,
-                        "public_ip_address": ec2_instance.public_ip_address or None,
-                        "private_dns_name": ec2_instance.private_dns_name or None,
-                        "public_dns_name": ec2_instance.public_dns_name or None,
-                    }
-                )
+        instance_details.append(
+            {
+                "instance_id": ec2_instance.id,
+                "instance_name": instance_name,
+                "availability_zone": ec2_instance.placement["AvailabilityZone"],
+                "vpc_id": ec2_instance.vpc_id,
+                "private_ip_address": ec2_instance.private_ip_address or None,
+                "public_ip_address": ec2_instance.public_ip_address or None,
+                "private_dns_name": ec2_instance.private_dns_name or None,
+                "public_dns_name": ec2_instance.public_dns_name or None,
+            }
+        )
 
     return instance_details


### PR DESCRIPTION
From version 0.8.7, `aws-gate ls` does not show instances without Name tag.