### PR TITLE
Support managed instances

### DIFF
--- a/aws_gate/query.py
+++ b/aws_gate/query.py
@@ -99,7 +99,7 @@ def query_instance(name, ec2=None):
 
     # If we are provided with instance ID directly, we don't need to contact EC2
     # API and can return the value directly.
-    if name.startswith("id-") or name.startswith("i-"):
+    if name.startswith("id-") or name.startswith("i-") or name.startswith("mi-"):
         return name
 
     if _is_valid_ip(name):


### PR DESCRIPTION
AWS Systems Manager has Managed Instances[1] which are usually on-prem
systems that have the SSM agent installed and can be controlled the same
as those instances hosted in AWS itself. They are prefixed with `mi-`.

[1]: https://docs.aws.amazon.com/systems-manager/latest/userguide/managed_instances.html