### PR TITLE
Make argument parsing easier to integrate with

### DIFF
--- a/aws_gate/cli.py
+++ b/aws_gate/cli.py
@@ -47,8 +47,8 @@ def _get_region(args, config, default):
     return region or config.default_region or default
 
 
-def parse_arguments():
-    parser = argparse.ArgumentParser(description=__description__)
+def get_argument_parser(*args, **kwargs):
+    parser = argparse.ArgumentParser(*args, **kwargs)
     parser.add_argument(
         "-v", "--verbose", help="increase output verbosity", action="store_true"
     )
@@ -176,6 +176,12 @@ def parse_arguments():
         default=",".join(DEFAULT_LIST_HUMAN_FIELDS),
     )
 
+    return parser, subparsers
+
+def parse_arguments(parser=None):
+    if not parser:
+        parser, *_ = get_argument_parser(description=__description__)
+
     args = parser.parse_args()
 
     if not args.subcommand:
@@ -185,8 +191,9 @@ def parse_arguments():
     return args
 
 
-def main():
-    args = parse_arguments()
+def main(args=None, argument_parser=None):
+    if not args:
+        args = parse_arguments(argument_parser)
 
     if not DEBUG:
         sys.excepthook = lambda exc_type, exc_value, traceback: logger.error(exc_value)


### PR DESCRIPTION
Split out argument parsing to some degree to make it easier for a third
party to integrate with.

For example:

```
$ cat foo.py
#!/usr/bin/env python3

from aws_gate import __version__, __description__
from aws_gate.cli import get_argument_parser
from aws_gate.cli import parse_arguments
from aws_gate.cli import main

parser, subparsers = get_argument_parser(
    prog='foo',
    conflict_handler='resolve',
    description=f'foo-{__description__}',
)

parser.add_argument(
    '--version',
    action='version',
    version=f'{parser.prog} 1234, aws-gate {__version__}',
)

foo_parser = subparsers.add_parser(
    'foo',
    help='Does foobar',
)

args = parse_arguments(parser)

main(args)

# Nothing matched in `main()` so execution fell through
# back to third party.
if args.subcommand == 'foo':
    print('here')

$ python3 foo.py foo
here
```