### PR TITLE
Make error visible

### DIFF
--- a/aws_gate/query.py
+++ b/aws_gate/query.py
@@ -30,8 +30,8 @@ def _query_aws_api(filters, ec2=None):
             if i.instance_id:
                 logger.debug("Matching instance: %s", i.instance_id)
                 ret = i.instance_id
-    except botocore.exceptions.ClientError:
-        raise AWSConnectionError
+    except botocore.exceptions.ClientError as e:
+        raise AWSConnectionError(e)
 
     return ret
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -14,7 +14,10 @@ def test_query_aws_api_exception(mocker):
     )
 
     filters = [{"Name": "ip-address", "Values": ["10.1.1.1"]}]
-    with pytest.raises(AWSConnectionError):
+    with pytest.raises(
+        AWSConnectionError,
+        match=r"^An error occurred \(ResourceInUseException\) when calling the random_ec2_op",
+    ):
         _query_aws_api(filters=filters, ec2=ec2_mock)
 
 


### PR DESCRIPTION
Not passing a message to `AWSConnectionError()` will result in commands
like `aws-gate ssh Name:foo` showing no output when an error occurs.