### PR TITLE
Basic windows support

### DIFF
--- a/aws_gate/decorators.py
+++ b/aws_gate/decorators.py
@@ -1,3 +1,4 @@
+import platform
 import logging
 import os
 from subprocess import PIPE

--- a/aws_gate/decorators.py
+++ b/aws_gate/decorators.py
@@ -26,7 +26,7 @@ def _plugin_exists_in_path():
 def plugin_required(
     wrapped_function, instance, args, kwargs
 ):  # pylint: disable=unused-argument
-    if not _plugin_exists(PLUGIN_INSTALL_PATH) and not _plugin_exists_in_path():
+    if not _plugin_exists(PLUGIN_INSTALL_PATH) and not _plugin_exists_in_path() and not platform.system() == "Windows":
         raise OSError("{} not found".format(PLUGIN_NAME))
 
     return wrapped_function(*args, **kwargs)

--- a/aws_gate/utils.py
+++ b/aws_gate/utils.py
@@ -113,7 +113,10 @@ def get_default_region():
 @contextlib.contextmanager
 def deferred_signals(signal_list=None):
     if signal_list is None:
-        signal_list = [signal.SIGHUP, signal.SIGINT, signal.SIGTERM]
+        if platform.system() == "Windows":
+            signal_list = [signal.SIGINT, signal.SIGTERM]
+        else:
+            signal_list = [signal.SIGHUP, signal.SIGINT, signal.SIGTERM]
 
     for deferred_signal in signal_list:
         signal_name = signal.Signals(deferred_signal).name

--- a/aws_gate/utils.py
+++ b/aws_gate/utils.py
@@ -113,10 +113,10 @@ def get_default_region():
 @contextlib.contextmanager
 def deferred_signals(signal_list=None):
     if signal_list is None:
-        if platform.system() == "Windows":
-            signal_list = [signal.SIGINT, signal.SIGTERM]
-        else:
+        if hasattr(signal, 'SIGHUP'):
             signal_list = [signal.SIGHUP, signal.SIGINT, signal.SIGTERM]
+        else:
+            signal_list = [signal.SIGINT, signal.SIGTERM]
 
     for deferred_signal in signal_list:
         signal_name = signal.Signals(deferred_signal).name


### PR DESCRIPTION
aws-gate currently doesn't run on Windows. This is a basic fix to make it running by adding some platform checks.

I did try to see if I could get `session-manager-plugin.exe` extracted to `~/.aws-gate/bin` from the installer package `SessionManagerPluginSetup.exe`, but does unfortunately not seem possible.

Therefor (on Windows) we now assume the user has run the setup prior to running aws-gate.