### PR TITLE
Enable SSH port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,45 @@ If you wish to execute a specific command (or plug it into your shell pipelines)
 Linux ip-172-31-35-173.eu-west-1.compute.internal 4.14.123-111.109.amzn2.x86_64 #1 SMP Mon Jun 10 19:37:57 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
 ```
 
+Local ports can be forwarded to another host and port relative to the target instance. This works as if by using ssh's `-L` option. Instead of executing a command, *aws-gate* establishes a forwarding session that can be used by other local applications.
+
+For example, you can use this to connect to a private web server by forwarding the instance's local port.
+
+```
+# Terminal 1
+% aws-gate ssh -L 8888:localhost:80 ssh-test
+
+# Terminal 2
+% curl localhost:8888
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+        <title>Test Page for the Nginx HTTP Server on Amazon Linux</title>
+...
+```
+
+Or you can use it to connect to a private RDS instance by forwarding the remote address and remote port.
+
+```
+# Terminal 1
+% aws-gate ssh -L 3306:privatedb.abcdef123456.eu-west-1.rds.amazonaws.com:3306 ssm-test
+
+# Terminal 2
+% mysql -h 127.0.0.1 -u root -P 3306 -p -e "SELECT User from mysql.user;"
+Enter password: 
++------------------+
+| User             |
++------------------+
+| root             |
+| mysql.infoschema |
+| mysql.session    |
+| mysql.sys        |
+| rdsadmin         |
++------------------+
+
+```
+
 ## Debugging mode
 
 If you run into issues, you can get detailed debug log by setting **GATE_DEBUG** environment variable:

--- a/aws_gate/cli.py
+++ b/aws_gate/cli.py
@@ -103,6 +103,9 @@ def get_argument_parser(*args, **kwargs):
         "-P", "--port", help="SSH port to use", type=int, default=DEFAULT_SSH_PORT
     )
     ssh_parser.add_argument(
+        "-L", "--forwarding", help="forward a local port to a remote host and port"
+    )
+    ssh_parser.add_argument(
         "--key-type",
         type=str,
         default=DEFAULT_KEY_ALGORITHM,
@@ -275,6 +278,7 @@ def main(args=None, argument_parser=None):
             key_type=args.key_type,
             key_size=args.key_size,
             command=args.command,
+            forwarding=args.forwarding,
         )
     elif args.subcommand == "ssh-config":
         ssh_config(

--- a/aws_gate/ssh.py
+++ b/aws_gate/ssh.py
@@ -43,6 +43,7 @@ class SshSession(BaseSession):
         port=DEFAULT_SSH_PORT,
         user=DEFAULT_OS_USER,
         command=None,
+        forwarding=None,
     ):
         self._instance_id = instance_id
         self._region_name = region_name
@@ -51,6 +52,7 @@ class SshSession(BaseSession):
         self._port = port
         self._user = user
         self._command = command
+        self._forwarding = forwarding
 
         self._ssh_cmd = None
 
@@ -72,6 +74,9 @@ class SshSession(BaseSession):
             "-i",
             DEFAULT_GATE_KEY_PATH,
         ]
+
+        if self._forwarding:
+            cmd.extend(["-N", "-L", self._forwarding])
 
         if DEBUG:
             cmd.append("-vv")
@@ -128,6 +133,7 @@ def ssh(
     profile_name=AWS_DEFAULT_PROFILE,
     region_name=AWS_DEFAULT_REGION,
     command=None,
+    forwarding=None,
 ):
     instance, profile, region = fetch_instance_details_from_config(
         config, instance_name, profile_name, region_name
@@ -163,5 +169,6 @@ def ssh(
                 port=port,
                 user=user,
                 command=command,
+                forwarding=forwarding,
             ) as ssh_session:
                 ssh_session.open()

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -45,6 +45,20 @@ def test_open_ssh_session_with_command(mocker, instance_id, ssm_mock):
     assert ["ls", "-l"] == m.call_args[0][1][-2:]
 
 
+def test_open_ssh_session_with_forwarding(mocker, instance_id, ssm_mock):
+    m = mocker.patch("aws_gate.ssh.execute", return_value="output")
+
+    rds_fwd = "3306:privatedb.abcdef123456.eu-west-1.rds.amazonaws.com:3306"
+
+    sess = SshSession(instance_id=instance_id, ssm=ssm_mock, forwarding=rds_fwd)
+    sess.open()
+
+    assert m.called
+    assert "-N" in m.call_args[0][1]
+    assert "-L" in m.call_args[0][1]
+    assert rds_fwd == m.call_args[0][1][1 + m.call_args[0][1].index("-L")]
+
+
 def test_open_ssh_session_host_key_verification(mocker, instance_id, ssm_mock):
     m = mocker.patch("aws_gate.ssh.execute", return_value="output")
 


### PR DESCRIPTION
This allows you to create an SSH tunnel to other VPC resources.

* Expose ssh's `-L` option in the aws-gate subcommand
* Document common use cases
* Add a basic test for code coverage

Resolves xen0l/aws-gate#712