### PR TITLE
docs(README): fix aws plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ brew tap xen0l/homebrew-taps
 brew install aws-gate
 
 # For installing session-manager-plugin via Homebrew (optional)
-brew cask install session-plugin-manager
+brew install --cask session-manager-plugin
 ```
 
 


### PR DESCRIPTION
Homebrew's API to install casks has changed, and the formula had a
typo in it. This change addresses both so that one can copy-paste the
instructions in their terminal.