### PR TITLE
Fixed default profile usage in session

### DIFF
--- a/aws_gate/session.py
+++ b/aws_gate/session.py
@@ -23,7 +23,7 @@ class SSMSession(BaseSession):
         self,
         instance_id,
         region_name=AWS_DEFAULT_REGION,
-        profile_name=AWS_DEFAULT_REGION,
+        profile_name=AWS_DEFAULT_PROFILE,
         ssm=None,
     ):
         self._instance_id = instance_id
@@ -61,5 +61,5 @@ def session(
         region,
         profile,
     )
-    with SSMSession(instance_id, region_name=region, ssm=ssm) as sess:
+    with SSMSession(instance_id, region_name=region, profile_name=profile, ssm=ssm) as sess:
         sess.open()


### PR DESCRIPTION
Fix for old issue #400

The default profile is misconfigured (it's using the region env var instead of profile) and not passed to SSMSession.

Relevant logs before:

```
docker run --rm -it -v $HOME/.aws-gate/config:/root/.aws-gate/config \
                    -v $HOME/.aws-gate/config.d:/root/.aws-gate/config.d \
                    -v $HOME/.aws:/root/.aws \
                    -e AWS_PROFILE=MyProfile -e GATE_DEBUG=1 \
                    adamdodev/aws-gate:latest session my-instance-name

2022-11-23 13:17:02,775 - aws_gate.utils               - DEBUG - Executing "session-manager-plugin {snip} eu-central-1 StartSession eu-west-1 {"Target": "i-REDACTED"} https://ssm.eu-central-1.amazonaws.com"

Starting session with SessionId: REDACTED


SessionId: REDACTED :
----------ERROR-------
Encountered error while initiating handshake. Handshake timed out. Please ensure that you have the latest version of the session manager plugin.
```

Note the `eu-west-1` where the profile name should be on the `session-manager-plugin` command.

Logs after fix:

```
docker run --rm -it -v $HOME/.aws-gate/config:/root/.aws-gate/config \
                    -v $HOME/.aws-gate/config.d:/root/.aws-gate/config.d \
                    -v $HOME/.aws:/root/.aws \
                    -e AWS_PROFILE=MyProfile -e GATE_DEBUG=1 \
                    adamdodev/aws-gate:latest session my-instance-name

2022-11-23 13:20:54,561 - aws_gate.utils               - DEBUG - Executing "session-manager-plugin {SNIP} eu-central-1 StartSession MyProfile {"Target": "i-05b1621c568831065"} https://ssm.eu-central-1.amazonaws.com"

Starting session with SessionId: REDACTED
This session is encrypted using AWS KMS.
sh-4.2$ echo "hello"
hello
```

