### PR TITLE
fix: allow = as a delimiter

### DIFF
--- a/aws_gate/query.py
+++ b/aws_gate/query.py
@@ -61,12 +61,14 @@ def getinstanceidbytag(name, ec2=None):
     # parsing. For this reason,we have to differentiate 2 cases for
     # provided name:
     # - aws: special prefixed tags in the form of aws:<service>:<tag_name>:<tag_value>
+    # - aws: special prefixed tags in the form of aws=<service>=<tag_name>=<tag_value>
     # - regular cases in the form <tag_name>:<tag_value>
+    # - regular cases in the form <tag_name>=<tag_value>
     if '=' in name:
         delimiter = '='
     else:
         delimiter = ':'
-    if name.startswith(f"aws{delimiter}:"):
+    if name.startswith(f"aws{delimiter}"):
         key, value = delimiter.join(name.split(delimiter, 3)[:3]), name.split(delimiter, 3)[-1]
     else:
         key, value = name.split(delimiter, 1)

--- a/aws_gate/query.py
+++ b/aws_gate/query.py
@@ -62,10 +62,14 @@ def getinstanceidbytag(name, ec2=None):
     # provided name:
     # - aws: special prefixed tags in the form of aws:<service>:<tag_name>:<tag_value>
     # - regular cases in the form <tag_name>:<tag_value>
-    if name.startswith("aws:"):
-        key, value = ":".join(name.split(":", 3)[:3]), name.split(":", 3)[-1]
+    if '=' in name:
+        delimiter = '='
     else:
-        key, value = name.split(":", 1)
+        delimiter = ':'
+    if name.startswith(f"aws{delimiter}:"):
+        key, value = delimiter.join(name.split(delimiter, 3)[:3]), name.split(delimiter, 3)[-1]
+    else:
+        key, value = name.split(delimiter, 1)
 
     filters = [{"Name": f"tag:{key}", "Values": [value]}]
     return _query_aws_api(filters=filters, ec2=ec2)


### PR DESCRIPTION
## what
- fix: allow = as a delimiter

## why
- For clients that use a colon in the tag name itself

## references
- Closes https://github.com/xen0l/aws-gate/issues/1753