### PR TITLE
fix(config.py): fix compatibility with marshmallow 4.x

### DIFF
--- a/aws_gate/config.py
+++ b/aws_gate/config.py
@@ -45,9 +45,9 @@ class HostSchema(Schema):
 
 class GateConfigSchema(Schema):
     defaults = fields.Nested(
-        DefaultsSchema, required=False, missing={}, validate=validate_defaults
+        DefaultsSchema, required=False, load_default={}, validate=validate_defaults
     )
-    hosts = fields.List(fields.Nested(HostSchema), required=False, missing=[])
+    hosts = fields.List(fields.Nested(HostSchema), required=False, load_default=[])
 
     # pylint: disable=unused-argument
     @post_load

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 boto3~=1.26.151
 cryptography==39.0.2
-marshmallow==3.19.0
+marshmallow~=4.0
 packaging==23.0
 PyYAML>=5.1,<6.1
 requests==2.31.0


### PR DESCRIPTION
https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#401-2025-08-28

> Previously-deprecated APIs have been removed, including:
>> default and missing parameters, which were replaced by dump_default and load_default in 3.13.0
